### PR TITLE
pip install git+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install
 -------
 * Install to python site-packages folder
 ```
-pip install https://github.com/pyscf/dftd3
+pip install git+https://github.com/pyscf/dftd3
 ```
 
 * Install in a custom folder for development


### PR DESCRIPTION
I had to use `pip install git+https://github.com/pyscf/dftd3` to get installation to work.