### PR TITLE
Fix link to extension module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ echo 'export PYSCF_EXT_PATH=/home/abc/local/path:$PYSCF_EXT_PATH' >> ~/.bashrc
 ```
 
 You can find more details of extended modules in the document
-[extension modules](http://pyscf.org/pyscf/install.html#extension-modules)
+[extension modules](http://pyscf.org/install.html#extension-modules)


### PR DESCRIPTION
Current link points to https://pyscf.org/pyscf/install.html#extension-modules, correct one seems to be https://pyscf.org/install.html#extension-modules

The same applies for most of the extension modules in the @pyscf namespace as well.