### PR TITLE
Correctly pass coordinates to DFTD3 as a column-major array in pyscf …

### DIFF
--- a/pyscf/dftd3/itrf.py
+++ b/pyscf/dftd3/itrf.py
@@ -261,7 +261,7 @@ class DFTD3Dispersion(lib.StreamObject):
         # dft-d3 has special treatment for def2-TZ basis
         tz = (basis_type == 'def2-TZ')
 
-        coords = mol.atom_coords()
+        coords = numpy.asfortranarray(mol.atom_coords())
         nuc_types = [gto.charge(mol.atom_symbol(ia))
                      for ia in range(mol.natm)]
         nuc_types = numpy.asarray(nuc_types, dtype=numpy.int32)


### PR DESCRIPTION
…1.7 and 2.0.

pyscf 2 has a change in behaviour: `Mol.atom_coords` now return a C-contiguous
(row-major) numpy array rather than a Fortran-contiguous (column-major) array.
The DFTD3 library is written in Fortran and expects the coordinates to be
supplied in column-major format. The change in behaviour of `Mol.atom_coords`
hence results in incorrect D3 energies:

```python
import pyscf
from pyscf import gto
from pyscf import dftd3

mol = gto.M(atom='''H 0.000000000000 0.000000000000 0.000000000000
C 0.000000000000 0.000000000000 1.087900000000
H 1.025681956337 0.000000000000 1.450533333333
H -0.512840978169 0.888266630391 1.450533333333
H -0.512840978169 -0.888266630391 1.450533333333
''')
d3 = dftd3.itrf.DFTD3Dispersion(mol)
d3.xc = 'B3LYP'

print(pyscf.__version__)
print(mol.atom_coords().flags)
print(d3.kernel()[0])
```

gives with pyscf 1.7.6:

```
1.7.6
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False

-0.0019136221730972761
```

but with 2.0.1:

```
2.0.1
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False

-0.0035960876396870295
```

Explicitly casting the coords array to be Fortran-contiguous fixes the
problem and is compatible with both pyscf 1.7 and 2.0. The energy computed
with pyscf 1.7 correctly matches that produced by running dftd3 standalone.

The CH4 example is added as a test and the tolerance on the existing H2O
test tightened sufficiently to detect this problem -- the difference in
the H2O D3 correction with the incorrect geometry is only 2e-6 Hartrees.