### PR TITLE
fix invalid warn msg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+libdftd3/
 
 # Local log files
 *~

--- a/pyscf/dftd3/itrf.py
+++ b/pyscf/dftd3/itrf.py
@@ -317,8 +317,8 @@ def _get_basis_type(mol):
                 break
         if (len(basis_types) > 1 and
             all(b == basis_type for b in basis_types)):
-            logger.warn('Mutliple types of basis found in mol.basis. '
-                        'Type %s is applied\n' % basis_type)
+            logger.warn(mol, 'Mutliple types of basis found in mol.basis. '
+                        'Type %s is applied\n', basis_type)
     else:
         basis_type = classify(mol.basis)
     return basis_type


### PR DESCRIPTION
Currently this logger.warn will cause an Error because 3 arguments are needed but it only provides one.